### PR TITLE
[FEATURE][CULTUREINFO][RESTAPI] 얼리버드 공연/전시 정보 가격정보 NaN 표시 에러 및 RESTAPI 호출 URL 수정

### DIFF
--- a/src/main/java/com/soop/pages/cultureinfo/controller/CultureInfoController.java
+++ b/src/main/java/com/soop/pages/cultureinfo/controller/CultureInfoController.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Map;
 
 @RestController
-@RequestMapping("/cultureInfo")
+@RequestMapping("/cultureinfo")
 public class CultureInfoController {
   private final CultureInfoService cultureInfoService;
 

--- a/src/main/resources/mapper/CultureInfoMapper.xml
+++ b/src/main/resources/mapper/CultureInfoMapper.xml
@@ -35,8 +35,8 @@
         POSTER,
 <!--        SELLER,-->
 <!--        SELLER_LINK,-->
-<!--        REGULAR_PRICE,-->
-<!--        DISCOUNT_PRICE,-->
+        REGULAR_PRICE,
+        DISCOUNT_PRICE,
         SALE_START_DATE,
         SALE_END_DATE,
         USAGE_START_DATE,


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
[FEATURE][CULTUREINFO][RESTAPI]

### 💡 작업동기
- 얼리버드 공연/전시 정보 가격정보 NaN 표시 에러 및 RESTAPI 호출 URL 수정작업입니다.

### 🔑 주요 변경사항
- 가격정보 DB에서 불러오는 데이터 주석처리 해제
- RESTAPI 호출 URL 수정(@RequestMapping("/cultureInfo") -> ("/cultureinfo"))

### 🏞 스크린샷
### @RequestMapping 추가 및 수정
![image](https://github.com/S-O-O-P/S-O-O-P-BackEnd/assets/73331620/e86520bf-3ccd-4a67-aa22-942faf5c7433)

### CultureInfoMapper.xml 수정
![image](https://github.com/S-O-O-P/S-O-O-P-BackEnd/assets/73331620/3c9c27f9-bbb3-4171-b586-3d4c7858e04c)


### 관련 이슈
- close #30 

### 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
