### PR TITLE
[REFACTOR][JWTSECURITY] 엑세스토큰 정보에 ProfilePic 정보 추가

### DIFF
--- a/src/main/java/com/soop/jwtsecurity/controller/ReissueController.java
+++ b/src/main/java/com/soop/jwtsecurity/controller/ReissueController.java
@@ -32,6 +32,7 @@ public class ReissueController {
     public void reissue(@RequestBody Map<String, Object> requestBody, HttpServletRequest request, HttpServletResponse response) throws IOException {
         String accessToken = null;
         Integer userCode = (Integer) requestBody.get("userCode");
+        String profilePic = (String) requestBody.get("profilePic");
 
         // 쿠키에서 액세스 토큰 추출
         Cookie[] cookies = request.getCookies();
@@ -89,7 +90,7 @@ public class ReissueController {
 
         // 새로운 액세스 토큰 발급
         String role = jwtUtil.getRoleFromRefreshToken(refreshToken);
-        String newAccessToken = jwtUtil.createJwt("access", signupPlatform, role, userCode, 300L * 1000);
+        String newAccessToken = jwtUtil.createJwt("access", signupPlatform, role, userCode, profilePic, 300L * 1000);
 
 
         createAndAddCookie(response, "access", newAccessToken);

--- a/src/main/java/com/soop/jwtsecurity/handler/CustomSuccessHandler.java
+++ b/src/main/java/com/soop/jwtsecurity/handler/CustomSuccessHandler.java
@@ -36,6 +36,8 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
         String username = customUserDetails.getUsername();
         int userCode = userMapper.findBySignupPlatform(username).getUserCode();
+        String profilePic = userMapper.findBySignupPlatform(username).getProfilePic();
+
 
         Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
         Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
@@ -43,7 +45,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String role = auth.getAuthority();
 
 
-        String access = jwtUtil.createJwt("access", username, role, userCode, 300L * 1000); // 10분 (600초)
+        String access = jwtUtil.createJwt("access", username, role, userCode, profilePic, 300L * 1000); // 10분 (600초)
 
         String existingRefreshToken = userMapper.searchRefreshEntity(username);
 
@@ -51,7 +53,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
             userMapper.deleteByRefresh(existingRefreshToken);
         }
 
-        String refresh = jwtUtil.createJwt("refresh", username, role, userCode, 86400L *1000); // 24시간 (86400000밀리초)
+        String refresh = jwtUtil.createJwt("refresh", username, role, userCode, profilePic, 86400L *1000); // 24시간 (86400000밀리초)
         addRefreshEntity(username, refresh, 86400L*1000);
 
         System.out.println("access = " + access);

--- a/src/main/java/com/soop/jwtsecurity/jwt/JWTUtil.java
+++ b/src/main/java/com/soop/jwtsecurity/jwt/JWTUtil.java
@@ -43,12 +43,15 @@ public class JWTUtil {
         return getClaims(token).get("category", String.class);
     }
 
-    public String createJwt(String category, String signupPlatform, String role,int userCode, Long expiredMs) {
+    public String getProfilePic(String token) { return getClaims(token).get("profilePic", String.class);}
+
+    public String createJwt(String category, String signupPlatform, String role,int userCode, String profilePic, Long expiredMs) {
         return Jwts.builder()
                 .claim("category", category)
                 .claim("signupPlatform", signupPlatform)
                 .claim("role", role)
                 .claim("userCode",userCode)
+                .claim("profilePic", profilePic)
                 .setIssuedAt(new Date(System.currentTimeMillis()))
                 .setExpiration(new Date(System.currentTimeMillis() + expiredMs))
                 .signWith(secretKey)


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
[REFACTOR][JWTSECURITY]

### 💡 작업동기
- 로그인 시 헤더에 프로필 사진 적용을 위해 엑세스토큰에 정보 추가

### 🔑 주요 변경사항
- access token에 profilePic 정보 추가

### 🏞 스크린샷
![image](https://github.com/user-attachments/assets/f7e131b2-0152-4710-b41b-fa0e576de448)

### 관련 이슈
- close #39 

### 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
