### PR TITLE
[REFACTOR][EDITPROFILE] 토큰 재발급 시 프로필 사진 호출

### DIFF
--- a/src/main/java/com/soop/jwtsecurity/controller/ReissueController.java
+++ b/src/main/java/com/soop/jwtsecurity/controller/ReissueController.java
@@ -32,7 +32,6 @@ public class ReissueController {
     public void reissue(@RequestBody Map<String, Object> requestBody, HttpServletRequest request, HttpServletResponse response) throws IOException {
         String accessToken = null;
         Integer userCode = (Integer) requestBody.get("userCode");
-        String profilePic = (String) requestBody.get("profilePic");
 
         // 쿠키에서 액세스 토큰 추출
         Cookie[] cookies = request.getCookies();
@@ -73,6 +72,9 @@ public class ReissueController {
             response.sendRedirect("http://localhost:3001/login?error=refresh_token_missing");
             return;
         }
+
+        // 프로필 사진 정보 조회
+        String profilePic = userMapper.getProfilePic(signupPlatform);
 
         // 리프레시 토큰 유효성 검사
         try {

--- a/src/main/java/com/soop/jwtsecurity/entityDTO/RefreshEntity.java
+++ b/src/main/java/com/soop/jwtsecurity/entityDTO/RefreshEntity.java
@@ -12,6 +12,7 @@ public class RefreshEntity {
 
     private Long userCode;
     private int refreshCode;
+    private String profilePic;
     private String signupPlatform;
     private String refresh;
     private String expiration;

--- a/src/main/java/com/soop/jwtsecurity/mapper/UserMapper.java
+++ b/src/main/java/com/soop/jwtsecurity/mapper/UserMapper.java
@@ -29,4 +29,6 @@ public interface UserMapper {
     void saveAboutMe(@Param("aboutme") String aboutme, @Param("signupPlatform") String signupPlatform,@Param("nickname") String nickname);
 
     void saveUserInterest(@Param("userCode") int userCode, @Param("interestCode") int interestCode);
+
+    String getProfilePic(String signupPlatform);
 }

--- a/src/main/resources/mapper/UserMapper.xml
+++ b/src/main/resources/mapper/UserMapper.xml
@@ -109,12 +109,14 @@
         INSERT INTO REFRESHENTITY
         (
         USER_CODE,
+        PROFILE_PIC,
         SIGNUP_PLATFORM,
         REFRESH,
         EXPIRATION
         )
         SELECT
         USER_CODE,
+        #{profilePic},
         #{signupPlatform},
         #{refresh},
         #{expiration}
@@ -127,7 +129,8 @@
 
     <select id="searchRefreshEntity" parameterType="com.soop.jwtsecurity.entityDTO.RefreshEntity">
         select
-                A.REFRESH
+                A.REFRESH,
+                B.PROFILE_PIC
             from REFRESHENTITY A
             join LINKBEE_USER B on A.SIGNUP_PLATFORM = B.SIGNUP_PLATFORM
         where A.SIGNUP_PLATFORM = #{signupPlatform}
@@ -173,6 +176,14 @@
         )
     </insert>
 
+    <!-- 프로필 사진 추가 -->
+    <select id="getProfilePic" parameterType="string" resultType="string">
+        SELECT
+                B.PROFILE_PIC
+          FROM REFRESHENTITY A
+          JOIN LINKBEE_USER B on A.SIGNUP_PLATFORM = B.SIGNUP_PLATFORM
+        where A.SIGNUP_PLATFORM = #{signupPlatform}
+    </select>
 
 
 </mapper>


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
[REFACTOR][EDITPROFILE] 

### 💡 작업동기
- 토큰 재발급을 통해 헤더 부분 프로필 사진 갱신

### 🔑 주요 변경사항
- reissue API 호출 시 profilePic 추가

### 🏞 스크린샷
- ReissueController 프로필 사진 정보 조회 추가
  ![image](https://github.com/user-attachments/assets/808db521-d12a-4179-bb17-5d67e2717b12)

- RefreshEntity에 profilePic 추가
  ![image](https://github.com/user-attachments/assets/93a4c829-1dcf-4809-b069-bae0e6d6591c)


- UserMapper.xml 프로필 사진 추가
  ![image](https://github.com/user-attachments/assets/5a314f4e-fd25-4983-a0de-dac2096907ba)

### 관련 이슈
- #41 

### 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
